### PR TITLE
[IT-2768] Update role name for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
     secrets: inherit
     with:
       CONTEXT: dev
-      ROLE_TO_ASSUME: arn:aws:iam::631692904429:role/sagebase-github-oidc-sage-ProviderRoledpemwaadeplo-1WMOA3PXXYS2T
+      ROLE_TO_ASSUME: arn:aws:iam::631692904429:role/sagebase-github-oidc-sage-bionetworks-dpe-airflow-infra
 
 # Uncomment and fill out 'ROLE_TO_ASSUME' to deploy to prod
 #  cdk-deploy-prod:


### PR DESCRIPTION
The CI role names to assume will change due to PR
Sage-Bionetworks-IT/organizations-infra#859. update to the new role names

depends on Sage-Bionetworks-IT/organizations-infra#859